### PR TITLE
Add '# ' as default way to make comments

### DIFF
--- a/art-fhicl-mode.el
+++ b/art-fhicl-mode.el
@@ -137,6 +137,8 @@
 
   (make-local-variable 'art-fhicl-indent-offset)
   (set (make-local-variable 'indent-line-function) 'art-fhicl-indent-line)
+  (setq comment-start "# ")
+  (setq comment-end "")
   (setq font-lock-defaults '(art-fhicl-font-lock-keywords))
   (setq major-mode 'art-fhicl-mode)
   (setq mode-name "art-fhicl")


### PR DESCRIPTION
Useful when doing `M-;` to comment a line or region